### PR TITLE
Add Jest tests for subscribe function

### DIFF
--- a/netlify/functions/subscribe.js
+++ b/netlify/functions/subscribe.js
@@ -2,19 +2,6 @@ const { GoogleSpreadsheet } = require('google-spreadsheet');
 const { JWT } = require('google-auth-library');
 
 exports.handler = async (event, context) => {
-  // Only allow POST requests
-  if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      },
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    };
-  }
-
   // Handle CORS preflight
   if (event.httpMethod === 'OPTIONS') {
     return {
@@ -25,6 +12,19 @@ exports.handler = async (event, context) => {
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
       },
       body: '',
+    };
+  }
+
+  // Only allow POST requests
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      },
+      body: JSON.stringify({ error: 'Method not allowed' }),
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -4,19 +4,28 @@
   "description": "Timeline tracking humanity's journey toward AGI",
   "main": "index.html",
   "dependencies": {
-    "google-spreadsheet": "^4.1.2",
-    "google-auth-library": "^9.4.1"
+    "google-auth-library": "^9.4.1",
+    "google-spreadsheet": "^4.1.2"
   },
   "scripts": {
     "dev": "netlify dev",
     "build": "echo 'No build step required'",
-    "deploy": "netlify deploy --prod"
+    "deploy": "netlify deploy --prod",
+    "test": "jest"
   },
-  "keywords": ["ai", "timeline", "agi", "progress"],
+  "keywords": [
+    "ai",
+    "timeline",
+    "agi",
+    "progress"
+  ],
   "author": "Vivek Kaushal",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/kaushalvivek/ai-progress-today.git"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/tests/subscribe.test.js
+++ b/tests/subscribe.test.js
@@ -1,0 +1,60 @@
+const subscribe = require('../netlify/functions/subscribe');
+
+// Mock google-spreadsheet and google-auth-library
+const mockSheet = {
+  setHeaderRow: jest.fn(),
+  getRows: jest.fn().mockResolvedValue([]),
+  addRow: jest.fn()
+};
+
+jest.mock('google-spreadsheet', () => {
+  return {
+    GoogleSpreadsheet: jest.fn().mockImplementation(() => ({
+      sheetsByTitle: { 'Subscribers': mockSheet },
+      loadInfo: jest.fn(),
+      addSheet: jest.fn(async ({ title }) => {
+        return mockSheet;
+      })
+    }))
+  };
+});
+
+jest.mock('google-auth-library', () => {
+  return { JWT: jest.fn() };
+});
+
+describe('subscribe function', () => {
+  test('successful subscription with valid email', async () => {
+    const event = {
+      httpMethod: 'POST',
+      body: JSON.stringify({ email: 'test@example.com' }),
+      headers: {}
+    };
+
+    const res = await subscribe.handler(event, {});
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('success');
+  });
+
+  test('rejection of invalid email', async () => {
+    const event = {
+      httpMethod: 'POST',
+      body: JSON.stringify({ email: 'invalid' }),
+      headers: {}
+    };
+
+    const res = await subscribe.handler(event, {});
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('OPTIONS preflight handling', async () => {
+    const event = {
+      httpMethod: 'OPTIONS',
+      headers: {}
+    };
+
+    const res = await subscribe.handler(event, {});
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency
- fix CORS preflight handling in subscribe function
- add test script
- create Jest tests simulating POST/OPTIONS events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684558017898832ba645e44196e07355